### PR TITLE
fix isp name issue

### DIFF
--- a/windowsinstall/Install.ps1
+++ b/windowsinstall/Install.ps1
@@ -199,10 +199,7 @@ while ($isp -ne "Starlink"){
     else{
         $isp=$sd.ISP
 
-        if ($isp -ne "Starlink"){
-            $msg=$messages.notstarlink
-            ShowTextDialog $(invoke-expression "echo $msg") "" "" -bigtext $true -infoonly $true
-        }
+
     }
 }
 


### PR DESCRIPTION
no longer insists that ISP be named Starlink. affects installer only. no need for existing users to upgrade.