### PR TITLE
Remove go get command

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 RUN apk update && apk add curl bash go
 RUN curl https://install.speedtest.net/app/cli/ookla-speedtest-1.1.1-linux-`uname -m`.tgz -o speedtest.tgz && tar -xzf speedtest.tgz && mv speedtest /usr/bin
-RUN go get github.com/fullstorydev/grpcurl/... && go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
+RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
 RUN mv ~/go/bin/grpcurl /usr/bin
 RUN curl https://raw.githubusercontent.com/Tysonpower/starlinkstatus/main/starlinkstatus_client.sh -o /usr/bin/starlinkstatus_client.sh && chmod +x /usr/bin/starlinkstatus_client.sh
 RUN speedtest --accept-license --accept-gdpr


### PR DESCRIPTION
go get no longer works outside of a module. Go install will do everything that is required to make this work.